### PR TITLE
feat: 소셜 게시판 좋아요, 댓글, 조회 개수 구현

### DIFF
--- a/src/main/java/com/example/onculture/domain/socialPost/domain/SocialPost.java
+++ b/src/main/java/com/example/onculture/domain/socialPost/domain/SocialPost.java
@@ -67,4 +67,24 @@ public class SocialPost {
         this.content = requestDTO.getContent();
         this.imageUrl = requestDTO.getImageUrl();
     }
+
+    public void increaseViewCount() {
+        this.viewCount++ ;
+    }
+
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    public void decreaseCommentCount() {
+        this.commentCount--;
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount--;
+    }
 }

--- a/src/main/java/com/example/onculture/domain/socialPost/domain/SocialPost.java
+++ b/src/main/java/com/example/onculture/domain/socialPost/domain/SocialPost.java
@@ -8,6 +8,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -48,6 +50,12 @@ public class SocialPost {
     @UpdateTimestamp
     @Column(nullable = false)
     private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @OneToMany(mappedBy = "socialPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "socialPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SocialPostLike> socialPostLikes = new ArrayList<>();
 
     @PreUpdate
     public void preUpdate() {

--- a/src/main/java/com/example/onculture/domain/socialPost/dto/CommentResponseDTO.java
+++ b/src/main/java/com/example/onculture/domain/socialPost/dto/CommentResponseDTO.java
@@ -13,6 +13,8 @@ public class CommentResponseDTO {
     private Long socialPostId;
     private Long userId;
     private String content;
+    private String userNickname;
+    private String userProfileImage;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -23,6 +25,8 @@ public class CommentResponseDTO {
         this.content = comment.getContent();
         this.createdAt = comment.getCreatedAt();
         this.updatedAt = comment.getUpdatedAt();
+        this.userNickname = comment.getUser().getProfile().getUser().getNickname();
+        this.userProfileImage = comment.getUser().getProfile().getProfileImage();
     }
 }
 

--- a/src/main/java/com/example/onculture/domain/socialPost/dto/PostResponseDTO.java
+++ b/src/main/java/com/example/onculture/domain/socialPost/dto/PostResponseDTO.java
@@ -18,6 +18,8 @@ public class PostResponseDTO {
     private int viewCount;
     private int commentCount;
     private int likeCount;
+    private String userNickname;
+    private String userProfileImage;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -32,5 +34,7 @@ public class PostResponseDTO {
         this.commentCount = socialPost.getCommentCount();
         this.createdAt = socialPost.getCreatedAt();
         this.updatedAt = socialPost.getUpdatedAt();
+        this.userNickname = socialPost.getUser().getProfile().getUser().getNickname();
+        this.userProfileImage = socialPost.getUser().getProfile().getProfileImage();
     }
 }

--- a/src/main/java/com/example/onculture/domain/socialPost/service/CommentService.java
+++ b/src/main/java/com/example/onculture/domain/socialPost/service/CommentService.java
@@ -64,6 +64,10 @@ public class CommentService {
 
         commentRepository.save(comment);
 
+        socialPost.increaseCommentCount();
+
+        socialPostRepository.save(socialPost);
+
         return new CommentResponseDTO(comment);
     }
 
@@ -106,6 +110,10 @@ public class CommentService {
         }
 
         commentRepository.deleteById(commentId);
+
+        socialPost.decreaseCommentCount();
+
+        socialPostRepository.save(socialPost);
 
         return "삭제 완료";
     }

--- a/src/main/java/com/example/onculture/domain/socialPost/service/SocialPostLikeService.java
+++ b/src/main/java/com/example/onculture/domain/socialPost/service/SocialPostLikeService.java
@@ -30,10 +30,18 @@ public class SocialPostLikeService {
         if (existingLike.isPresent()) {
             socialPostLikeRepository.delete(existingLike.get());  // 이미 존재하면 좋아요 취소
 
+            socialPost.decreaseLikeCount();
+
+            socialPostRepository.save(socialPost);
+
             return "좋아요 취소";
         } else {
             SocialPostLike newLike = new SocialPostLike(user, socialPost);
             socialPostLikeRepository.save(newLike);  // 존재하지 않으면 좋아요 추가
+
+            socialPost.increaseLikeCount();
+
+            socialPostRepository.save(socialPost);
 
             return "좋아요 추가";
         }

--- a/src/main/java/com/example/onculture/domain/socialPost/service/SocialPostService.java
+++ b/src/main/java/com/example/onculture/domain/socialPost/service/SocialPostService.java
@@ -52,10 +52,14 @@ public class SocialPostService {
     }
 
     public PostResponseDTO getSocialPost(Long socialPostId) {
-        return socialPostRepository
-                .findById(socialPostId)
-                .map(PostResponseDTO::new)
+        SocialPost socialPost = socialPostRepository.findById(socialPostId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        socialPost.increaseViewCount();
+
+        socialPostRepository.save(socialPost);
+
+        return new PostResponseDTO(socialPost);
     }
 
     public UserPostListResponseDTO getSocialPostsByUser(Long userId, int pageNum, int pageSize) {


### PR DESCRIPTION
* 게시글 및 댓글 조회 API 응답에 작성자의 닉네임과 프로필 이미지 URL을 포함하도록 변경함.

1. 게시글 응답(PostResponseDTO)에 nickname과 profileImage 필드 추가
2. 댓글 응답(CommentResponseDTO)에도 동일한 필드 추가

* 게시글 좋아요, 댓글, 조회 개수 구현

* 소셜 게시판 Cascade Rule 적용

✅ 체크리스트