### PR TITLE
Fix : 에러 코드에 UNAUTHORIZED_ACCESS가 중복 정의되어 있음

### DIFF
--- a/src/main/java/com/example/onculture/global/exception/CustomException.java
+++ b/src/main/java/com/example/onculture/global/exception/CustomException.java
@@ -51,7 +51,7 @@ public class CustomException extends RuntimeException {
 	// 로그인하지 않은 사용자 접근 시
 	public static class CustomAuthenticationException extends CustomException {
 		public CustomAuthenticationException() {
-			super(ErrorCode.UNAUTHORIZED_ACCESS);
+			super(ErrorCode.UNAUTHORIZED_ACCESS_TOKEN);
 		}
 	}
 

--- a/src/main/java/com/example/onculture/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/onculture/global/exception/ErrorCode.java
@@ -47,7 +47,7 @@ public enum ErrorCode {
 	UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다. [로그인] 또는 [회원가입] 후 다시 시도해주세요."),
 	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효한 리프레시 토큰이 아닙니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효한 토큰이 아닙니다."),
-	UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),		// 로그인하지 않은 사용자 접근 시
+	UNAUTHORIZED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),		// 로그인하지 않은 사용자 접근 시
 	INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
 	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다."),
 	REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 RefreshToken 토큰 입니다. 재로그인 해주세요."),

--- a/src/main/java/com/example/onculture/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/onculture/global/exception/GlobalExceptionHandler.java
@@ -83,8 +83,8 @@ public class GlobalExceptionHandler {
 	// 로그인하지 않은 사용자 접근 예외 핸들러
 	@ExceptionHandler(CustomException.CustomAuthenticationException.class)
 	public ResponseEntity<ErrorResponse> handleCustomAuthenticationException(CustomException.CustomAuthenticationException ex) {
-		ErrorResponse errorResponse = new ErrorResponse(ErrorCode.UNAUTHORIZED_ACCESS);
-		return ResponseEntity.status(ErrorCode.UNAUTHORIZED_ACCESS.getStatus()).body(errorResponse);
+		ErrorResponse errorResponse = new ErrorResponse(ErrorCode.UNAUTHORIZED_ACCESS_TOKEN);
+		return ResponseEntity.status(ErrorCode.UNAUTHORIZED_ACCESS_TOKEN.getStatus()).body(errorResponse);
 	}
 
 	// 로그인했지만 권한 부족 예외 핸들러


### PR DESCRIPTION
- 인증 기능에서 사용하는 에러코드를 수정함 UNAUTHORIZED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.")