### PR TITLE
Fix/profile/#111

### DIFF
--- a/src/main/java/com/example/onculture/domain/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/onculture/domain/oauth/handler/OAuth2SuccessHandler.java
@@ -54,8 +54,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         tokenService.addAllTokenToCookie(request, response, accessToken, refreshToken);
         // 인증 관련 설정값, 쿠키 제거
         clearAuthenticationAttributes(request, response);
+        System.out.println("accessToken: " + accessToken);
+        response.setHeader("Authorization", "Bearer " + accessToken);
+
         // application.properties 에서 리다이렉트 uri 변경 가능 ( 기본값 : 백엔드 테스트용 리다이렉트 uri
-        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+        getRedirectStrategy().sendRedirect(request, response, redirectUri+"?access_token="+accessToken);
     }
 
     // 인증 관련 설정값, 쿠키 제거

--- a/src/main/java/com/example/onculture/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/onculture/domain/user/controller/UserController.java
@@ -32,7 +32,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 @Slf4j
@@ -74,9 +76,11 @@ public class UserController {
     // 액세스 토큰 재발급 API
     @Operation( summary = "액세스 토큰 재발급 API", description = "refreshToken 토큰이 만료되어 있다면 기존 저장된 토큰 삭제 및 로그인 페이지로 리다이렉트" )
     @PostMapping("/refresh-token")
-    public ResponseEntity<SuccessResponse<String>> refreshToken(HttpServletRequest request, HttpServletResponse response) {
-        userService.refreshToken(request, response);
-        return ResponseEntity.ok(SuccessResponse.success(HttpStatus.OK, "액세스 토큰 재발급 성공"));
+    public ResponseEntity<SuccessResponse<?>> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken =  userService.refreshToken(request, response);
+        Map<String, String> result = new HashMap<>();
+        result.put("access_token", "Bearer " + accessToken);
+        return ResponseEntity.ok(SuccessResponse.success(HttpStatus.OK, "액세스 토큰 재발급 성공", result));
     }
 
     // 닉네임 중복 체크 API

--- a/src/main/java/com/example/onculture/domain/user/service/TokenService.java
+++ b/src/main/java/com/example/onculture/domain/user/service/TokenService.java
@@ -28,9 +28,6 @@ public class TokenService {
 
     // 생성된 액세스 및 리프레시 토큰을 쿠키에 저장
     public void addAllTokenToCookie(HttpServletRequest request, HttpServletResponse response, String accessToken, String refreshToken) {
-        // 기존 토큰 쿠키 삭제
-        CookieUtil.deleteCookie(request, response, ACCESS_TOKEN_COOKIE_NAME);
-        CookieUtil.deleteCookie(request, response, REFRESH_TOKEN_COOKIE_NAME);
         // 새로운 토큰 쿠키 생성
         CookieUtil.addCookie(response, ACCESS_TOKEN_COOKIE_NAME, accessToken, ACCESS_TOKEN_COOKIE_DURATION);
         CookieUtil.addSecurityCookie(response, REFRESH_TOKEN_COOKIE_NAME, refreshToken, REFRESH_TOKEN_COOKIE_DURATION);

--- a/src/main/java/com/example/onculture/domain/user/service/UserService.java
+++ b/src/main/java/com/example/onculture/domain/user/service/UserService.java
@@ -78,7 +78,6 @@ public class UserService {
         String nickname = dto.getNickname().trim();
 
         // 중복 이메일 검증 로직 추가
-        // isPresent() : Optional 객체에서 제공하는 메서드로, 해당 Optional 객체가 값을 가지고 있는지 여부를 확인하는 메서드 ( 값이 있을 경우 True )
         if (userRepository.existsByEmail(email)) throw new CustomException.DuplicateEmailException();     // 커스텀한 중복 이메일 예외
         // 중복 닉네임 검증 로직 추가
         if (userRepository.existsByNickname(nickname)) throw new CustomException.DuplicateNicknameException();      // 커스텀한 중복 닉네임 예외
@@ -131,7 +130,7 @@ public class UserService {
     }
 
     // 재발급 메서드
-    public void refreshToken(HttpServletRequest request, HttpServletResponse response) {
+    public String refreshToken(HttpServletRequest request, HttpServletResponse response) {
         // request를 통해 쿠키에서 refreshToken 가져오기
         String refreshToken = extractRefreshToken(request);
         // 리프레시 토큰 만료로 없을 경우, 재로그인 요청 메세지 반환
@@ -142,6 +141,8 @@ public class UserService {
         log.info("재발급된 액세스 토큰 : " + accessToken);
         // 쿠키에 액세스 토큰 저장
         CookieUtil.addCookie(response, ACCESS_TOKEN_COOKIE_NAME, accessToken, ACCESS_TOKEN_COOKIE_DURATION);
+
+        return accessToken;
     }
 
     // 닉네임 중복 여부 메서드
@@ -190,7 +191,7 @@ public class UserService {
         // 닉네임 업데이트
         user.setNickname(dto.getNickname().trim());
 
-        // 비밀번호 업데이트 (로컬 회원가입 사용자이면 비밀번호 입력 필수)
+        // 비밀번호 업데이트 (로컬 회원가입 사용자이고 비밀번호 입력했으면 비밀번호 수정)
         if (!user.getLoginType().equals(LoginType.SOCIAL_ONLY) && dto.getPassword() != null && !dto.getPassword().trim().isEmpty()) {
             user.setPassword(passwordEncoder.encode(dto.getPassword().trim()));
         }
@@ -216,11 +217,9 @@ public class UserService {
 
     // 프로필 이미지 파일 S3 저장 및 파일명 반환 메서드
     public String profileImageSave(ModifyRequestDTO dto, MultipartFile imageData, User user) {
-
         String imageFileName = "";
 
         if (imageData != null && !imageData.isEmpty()) {
-
             if (user.getProfile().getProfileImage() != null && !user.getProfile().getProfileImage().isEmpty()) {
                 // S3에 있는 기존 이미지 파일 삭제
                 awsS3Util.deleteFile(user.getProfile().getProfileImage());

--- a/src/main/java/com/example/onculture/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/onculture/global/config/WebSecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -43,6 +44,8 @@ public class WebSecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // cors 설정
+                .cors(Customizer.withDefaults())
                 // 특정 경로에 대한 액세스 설정
                 .authorizeHttpRequests(auth -> auth
 

--- a/src/main/java/com/example/onculture/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/onculture/global/config/WebSecurityConfig.java
@@ -45,7 +45,7 @@ public class WebSecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // cors 설정
-                .cors(Customizer.withDefaults())
+//                .cors(Customizer.withDefaults())
                 // 특정 경로에 대한 액세스 설정
                 .authorizeHttpRequests(auth -> auth
 

--- a/src/main/java/com/example/onculture/global/utils/CookieUtil.java
+++ b/src/main/java/com/example/onculture/global/utils/CookieUtil.java
@@ -23,9 +23,8 @@ public class CookieUtil {
         // ResponseCookie를 사용하여 쿠키 생성
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .path("/")               // 전체 도메인에서 사용 가능하도록 설정
-                .sameSite("None")        // SameSite=None을 명시적으로 설정하여 크로스사이트 요청 허용
-                .httpOnly(false)        // 액세스 토큰용이므로 HttpOnly 설정하지 않음 (프론트엔드에서 쿠키를 접근 가능하게 설정)
-                .secure(false)           // HTTP 환경에서는 Secure=false로 설정
+//                .sameSite("None")        // SameSite=None을 명시적으로 설정하여 크로스사이트 요청 허용
+//                .secure(false)           // HTTP 환경에서는 Secure=false로 설정
                 .maxAge(maxAge)          // 쿠키 유효 시간 설정 (초 단위)
                 .build();
 
@@ -38,9 +37,9 @@ public class CookieUtil {
         // ResponseCookie를 사용하여 쿠키 생성
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .path("/")               // 전체 도메인에서 사용 가능하도록 설정
-                .sameSite("None")        // SameSite=None을 명시적으로 설정하여 크로스사이트 요청 허용
                 .httpOnly(true)         // HttpOnly 설정 (프론트엔드에서 쿠키를 읽지 못하도록)
-                .secure(false)           // HTTP 환경에서는 Secure=false로 설정
+//                .sameSite("None")        // SameSite=None을 명시적으로 설정하여 크로스사이트 요청 허용
+//                .secure(false)           // HTTP 환경에서는 Secure=false로 설정
                 .maxAge(maxAge)          // 쿠키 유효 시간 설정 (초 단위)
                 .build();
 
@@ -58,8 +57,8 @@ public class CookieUtil {
                 // ResponseCookie로 쿠키 삭제 설정
                 ResponseCookie cookieToDelete = ResponseCookie.from(name, "")  // 쿠키 값은 빈 문자열로 설정
                         .path("/")                  // 쿠키의 경로는 그대로 유지
-                        .sameSite("None")           // SameSite=None 설정 (Cross-Site 요청 허용)
-                        .secure(false)              // HTTP 환경에서만 사용
+//                        .sameSite("None")           // SameSite=None 설정 (Cross-Site 요청 허용)
+//                        .secure(false)              // HTTP 환경에서만 사용
                         .maxAge(0)                  // 유효 시간을 0으로 설정하여 만료 처리
                         .build();
 

--- a/src/main/java/com/example/onculture/global/utils/CookieUtil.java
+++ b/src/main/java/com/example/onculture/global/utils/CookieUtil.java
@@ -24,7 +24,7 @@ public class CookieUtil {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .path("/")               // 전체 도메인에서 사용 가능하도록 설정
 //                .sameSite("None")        // SameSite=None을 명시적으로 설정하여 크로스사이트 요청 허용
-//                .secure(false)           // HTTP 환경에서는 Secure=false로 설정
+//                .secure(true)           // HTTP 환경에서는 Secure=false로 설정
                 .maxAge(maxAge)          // 쿠키 유효 시간 설정 (초 단위)
                 .build();
 
@@ -39,7 +39,7 @@ public class CookieUtil {
                 .path("/")               // 전체 도메인에서 사용 가능하도록 설정
                 .httpOnly(true)         // HttpOnly 설정 (프론트엔드에서 쿠키를 읽지 못하도록)
 //                .sameSite("None")        // SameSite=None을 명시적으로 설정하여 크로스사이트 요청 허용
-//                .secure(false)           // HTTP 환경에서는 Secure=false로 설정
+//                .secure(true)           // HTTP 환경에서는 Secure=false로 설정
                 .maxAge(maxAge)          // 쿠키 유효 시간 설정 (초 단위)
                 .build();
 
@@ -58,7 +58,7 @@ public class CookieUtil {
                 ResponseCookie cookieToDelete = ResponseCookie.from(name, "")  // 쿠키 값은 빈 문자열로 설정
                         .path("/")                  // 쿠키의 경로는 그대로 유지
 //                        .sameSite("None")           // SameSite=None 설정 (Cross-Site 요청 허용)
-//                        .secure(false)              // HTTP 환경에서만 사용
+//                        .secure(true)              // HTTP 환경에서만 사용
                         .maxAge(0)                  // 유효 시간을 0으로 설정하여 만료 처리
                         .build();
 

--- a/src/main/java/com/example/onculture/global/utils/CookieUtil.java
+++ b/src/main/java/com/example/onculture/global/utils/CookieUtil.java
@@ -3,6 +3,7 @@ package com.example.onculture.global.utils;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
 import org.springframework.util.SerializationUtils;
 
 import java.time.Duration;
@@ -18,34 +19,52 @@ public class CookieUtil {
     public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";    // OAuth2 인가 요청 쿠키 이름
     public final static int COOKIE_EXPIRE_SECONDS = 18000;      // OAuth2 인가 요청 쿠키의 유효 시간 ( 18000 = 5seconds )
 
-    // 요청값(이름, 값, 만료 기간)을 바탕으로 쿠키 생성 메서드
     public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setPath("/");       // 전체 도메인에서 사용 가능하도록 설정
-        cookie.setMaxAge(maxAge);  // 쿠키 유효 시간 설정 (초 단위)
-        response.addCookie(cookie);
+        // ResponseCookie를 사용하여 쿠키 생성
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .path("/")               // 전체 도메인에서 사용 가능하도록 설정
+                .sameSite("None")        // SameSite=None을 명시적으로 설정하여 크로스사이트 요청 허용
+                .httpOnly(false)        // 액세스 토큰용이므로 HttpOnly 설정하지 않음 (프론트엔드에서 쿠키를 접근 가능하게 설정)
+                .secure(false)           // HTTP 환경에서는 Secure=false로 설정
+                .maxAge(maxAge)          // 쿠키 유효 시간 설정 (초 단위)
+                .build();
+
+        // 쿠키를 응답에 추가
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 
-    // 리프레시 전용 쿠키 생성 메서드
+    // 리프레시 전용 쿠키 생성 메서드 (HttpOnly 설정)
     public static void addSecurityCookie(HttpServletResponse response, String name, String value, int maxAge) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setHttpOnly(true);   // XSS 공격 방지를 위해 HttpOnly 설정
-        cookie.setPath("/");
-        cookie.setMaxAge(maxAge);
-        response.addCookie(cookie);
+        // ResponseCookie를 사용하여 쿠키 생성
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .path("/")               // 전체 도메인에서 사용 가능하도록 설정
+                .sameSite("None")        // SameSite=None을 명시적으로 설정하여 크로스사이트 요청 허용
+                .httpOnly(true)         // HttpOnly 설정 (프론트엔드에서 쿠키를 읽지 못하도록)
+                .secure(false)           // HTTP 환경에서는 Secure=false로 설정
+                .maxAge(maxAge)          // 쿠키 유효 시간 설정 (초 단위)
+                .build();
+
+        // 쿠키를 응답에 추가
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 
     // 쿠키의 이름을 입력받아 쿠키 삭제
     public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
         Cookie[] cookies = request.getCookies();
-        if ( cookies == null ) return;
+        if (cookies == null) return;
 
-        for ( Cookie cookie : cookies ) {
+        for (Cookie cookie : cookies) {
             if (name.equals(cookie.getName())) {
-                cookie.setValue("");
-                cookie.setPath("/");
-                cookie.setMaxAge(0);
-                response.addCookie(cookie);
+                // ResponseCookie로 쿠키 삭제 설정
+                ResponseCookie cookieToDelete = ResponseCookie.from(name, "")  // 쿠키 값은 빈 문자열로 설정
+                        .path("/")                  // 쿠키의 경로는 그대로 유지
+                        .sameSite("None")           // SameSite=None 설정 (Cross-Site 요청 허용)
+                        .secure(false)              // HTTP 환경에서만 사용
+                        .maxAge(0)                  // 유효 시간을 0으로 설정하여 만료 처리
+                        .build();
+
+                // 응답에 쿠키 삭제를 반영
+                response.addHeader("Set-Cookie", cookieToDelete.toString());
             }
         }
     }
@@ -63,4 +82,59 @@ public class CookieUtil {
                         Base64.getUrlDecoder().decode(cookie.getValue()))
         );
     }
+
+    // 개선 전
+    /*
+    // 요청값(이름, 값, 만료 기간)을 바탕으로 쿠키 생성 메서드
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");       // 전체 도메인에서 사용 가능하도록 설정
+        cookie.setSecure(false);   // HTTP 환경에서는 Secure=false로 설정
+        cookie.setMaxAge(maxAge);  // 쿠키 유효 시간 설정 (초 단위)
+
+        // SameSite=None을 명시적으로 설정하여 크로스사이트 요청 허용
+        cookie.setAttribute("SameSite", "None");
+        response.addCookie(cookie);
+
+        // 쿠키 헤더에도 SameSite=None 적용 (브라우저가 SameSite 속성을 인식하도록)
+        response.addHeader("Set-Cookie", String.format(
+                "%s=%s; Path=/; Max-Age=%d; HttpOnly; SameSite=None",
+                name, value, maxAge));
+    }
+
+    // 리프레시 전용 쿠키 생성 메서드 (HttpOnly 설정)
+    public static void addSecurityCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);   // XSS 공격 방지를 위해 HttpOnly 설정
+        cookie.setSecure(false);    // HTTP 환경에서는 Secure=false로 설정
+        cookie.setMaxAge(maxAge);
+        cookie.setAttribute("SameSite", "None");  // Cross-Site 요청 허용
+        response.addCookie(cookie);
+
+        // 쿠키 헤더에도 SameSite=None 적용
+        response.addHeader("Set-Cookie", String.format(
+                "%s=%s; Path=/; Max-Age=%d; HttpOnly; SameSite=None",
+                name, value, maxAge));
+    }
+
+    // 쿠키의 이름을 입력받아 쿠키 삭제
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if ( cookies == null ) return;
+
+        for ( Cookie cookie : cookies ) {
+            if (name.equals(cookie.getName())) {
+                cookie.setValue("");
+                cookie.setPath("/");
+                cookie.setSecure(false);        // HTTP 에서만 전송 (HTTPS일 경우 true로 변경)
+                cookie.setMaxAge(0);
+                cookie.setAttribute("SameSite", "None");        // Cross-Site 요청 허용
+                response.addCookie(cookie);
+            }
+        }
+    }
+     */
+
+
 }

--- a/src/main/java/com/example/onculture/global/utils/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/onculture/global/utils/jwt/JwtTokenProvider.java
@@ -29,8 +29,8 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     private final Key key;      // 서명 키
-    private static final Long ACCESS_TOKEN_EXPIRATION_IN_SECONDS = Duration.ofHours(1).getSeconds();
-    private static final Long REFRESH_TOKEN_EXPIRATION_IN_SECONDS = Duration.ofDays(14).getSeconds();
+    private static final Long ACCESS_TOKEN_EXPIRATION_IN_SECONDS = Duration.ofDays(14).getSeconds();        // 2주
+    private static final Long REFRESH_TOKEN_EXPIRATION_IN_SECONDS = Duration.ofDays(28).getSeconds();       // 4주
     public final UserRepository userRepository;
 
     // application.properties에 설정된 값 반영


### PR DESCRIPTION
1. HTTPS 대비 쿠키 세팅
2. 토큰 유효시간 연장 ( 액세스 토큰 2주, 리프레시 토큰 4주 )
3. 토큰 반환 방식 추가
- 액세스 토큰 재발급 API : 반환값에 액세스 토큰 추가
- 소셜 로그인 : 헤더와 리다이렉트 URI 파라미터에 포함