### PR TITLE
feat: 소셜 게시판 목록 조회 쿼리 최적화

### DIFF
--- a/src/main/java/com/example/onculture/domain/socialPost/repository/SocialPostLikeRepository.java
+++ b/src/main/java/com/example/onculture/domain/socialPost/repository/SocialPostLikeRepository.java
@@ -4,6 +4,7 @@ import com.example.onculture.domain.socialPost.domain.SocialPost;
 import com.example.onculture.domain.socialPost.domain.SocialPostLike;
 import com.example.onculture.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,5 +14,8 @@ public interface SocialPostLikeRepository extends JpaRepository<SocialPostLike, 
     List<Long> findSocialPostIdByUserId(Long userId);
     boolean existsByUserAndSocialPost(User user, SocialPost socialPost);
     boolean existsByUserIdAndSocialPostId(Long userId, Long socialPostId);
+
+    @Query("select spl.socialPost.id from SocialPostLike spl where spl.user.id = :userId and spl.socialPost.id in :socialPostIds")
+    List<Long> findSocialPostIdsByUserIdAndSocialPostIds(Long userId, List<Long> socialPostIds);
 
 }

--- a/src/main/java/com/example/onculture/domain/socialPost/repository/SocialPostRepository.java
+++ b/src/main/java/com/example/onculture/domain/socialPost/repository/SocialPostRepository.java
@@ -1,15 +1,28 @@
 package com.example.onculture.domain.socialPost.repository;
 
 
+import com.example.onculture.domain.socialPost.domain.SocialPostLike;
 import lombok.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import com.example.onculture.domain.socialPost.domain.SocialPost;
+
+import java.util.List;
 
 @Repository
 public interface SocialPostRepository extends JpaRepository<SocialPost, Long> {
     Page<SocialPost> findByUserId(Long userId, Pageable pageable);
+
+    // n + 1 문제 해결을 위한 패치 조인 쿼리
+    @Query(value = "select sp from SocialPost sp " +
+            "join fetch sp.user u " +
+            "left join fetch u.profile",
+            countQuery = "select count(sp) from SocialPost sp")
+    Page<SocialPost> findAllWithUserAndProfile(Pageable pageable);
 }
+
+
 


### PR DESCRIPTION
1. 게시판 목록 조회에 fetch join을 적용해서 user와 profile을 같이 가져오게 변경
2. 게시판 목록 조회에 좋아요 여부를 기존 map 함수로 개별로 쿼리를 날려서 확인하는 로직에서 한번에 처리되게 변경